### PR TITLE
feat: update base path in Vite configuration for proper asset loading

### DIFF
--- a/product-management/vite.config.ts
+++ b/product-management/vite.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',  // Add this line for proper asset loading
+  base: '/product-management/', // Only add this if deploying to a subfolder
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/product-management/vite.config.ts
+++ b/product-management/vite.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/product-management/', // Only add this if deploying to a subfolder
+  base: process.env.NODE_ENV === 'production' ? '/product-management/' : '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -15,8 +15,8 @@ export default defineConfig({
     sourcemap: true
   },
   server: {
-    port: 3000, // Updated port
-    host: true, // Listen on all network interfaces
-    open: true, // Open browser automatically
-  },
+    port: 3000,
+    host: true,
+    open: true
+  }
 })


### PR DESCRIPTION
Uses root path ('/') for local development
Only uses '/product-management/' in production
Keeps localhost running on port 3000 normally
For deployment:

Netlify: Remove base path completely and use _redirects
Vercel: Remove base path and use vercel.json
GitHub Pages: Keep the base path as /product-management/